### PR TITLE
Changes that make change_version functional

### DIFF
--- a/release-script/for-all-boosters.sh
+++ b/release-script/for-all-boosters.sh
@@ -168,13 +168,15 @@ change_version() {
         cmd="sed -i '' -e 's/<version>${escapedCurrent}</<version>${newVersion}</g' pom.xml"
     fi
     echo "${cmd}"
+
+    eval ${cmd}
     
-    if ${cmd}; then
+    if [ $? -eq 0 ]; then
         find . -name "*.versionsBackup" -delete
         git diff
         git reset --hard upstream/${BRANCH}
         return 0
-    
+
         # Only attempt committing if we have changes otherwise the script will exit
         if [[ `git status --porcelain` ]]; then
             log "Updated ${target} from ${YELLOW}${currentVersion}${BLUE} to ${YELLOW}${newVersion}"

--- a/release-script/for-all-boosters.sh
+++ b/release-script/for-all-boosters.sh
@@ -165,7 +165,7 @@ change_version() {
     if [ "${targetParent}" == true ]; then
         local escapedCurrent=$(sed 's|[]\/$*.^[]|\\&|g' <<< ${currentVersion})
         echo "${escapedCurrent}"
-        cmd="sed -i '' -e 's/<version>${escapedCurrent}</<version>${newVersion}</g' pom.xml"
+        cmd="sed -i -e 's/<version>${escapedCurrent}</<version>${newVersion}</g' pom.xml"
     fi
     echo "${cmd}"
 

--- a/release-script/for-all-boosters.sh
+++ b/release-script/for-all-boosters.sh
@@ -173,9 +173,6 @@ change_version() {
     
     if [ $? -eq 0 ]; then
         find . -name "*.versionsBackup" -delete
-        git diff
-        git reset --hard upstream/${BRANCH}
-        return 0
 
         # Only attempt committing if we have changes otherwise the script will exit
         if [[ `git status --porcelain` ]]; then


### PR DESCRIPTION
I executed the following tests:

```
./release-script/for-all-boosters.sh -d change_version
./release-script/for-all-boosters.sh -d change_version -v 1.5.10-7-SNAPSHOT
./release-script/for-all-boosters.sh -d change_version -p
./release-script/for-all-boosters.sh -d change_version -p 1.5.10-14
```

They all past (except the 3rd one that failed to build the booster since the artifactId for the parent didn't exist)