### PR TITLE
Use long option when deleting branch

### DIFF
--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -243,7 +243,7 @@ delete_branch() {
         log "Press any key to continue or ctrl-c to abort."
         read foo
 
-        push_to_remote upstream -d
+        push_to_remote upstream --delete
     else
         log_ignored "Branch doesn't exist on remote"
     fi


### PR DESCRIPTION
The short option seems to not be present on some versions of git