### PR TITLE
Add a manual list of dependencies needed by the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 
 A script that operates on all boosters identified as sub-directories (named with the `spring-boot-*-booster` pattern) of the directory in which the script runs. 
 
-Run `for-all-boosters.sh -h` for an overview of what the script can do and how to use it. 
+Run `for-all-boosters.sh -h` for an overview of what the script can do and how to use it.
+
+### Dependencies
+
+* git
+* perl
+* mvn
+* oc
 
 ## `sync-descriptors.sh`
 


### PR DESCRIPTION
I couldn't find a why that would allow us to automatically derive the
dependencies of the script, so manual labor of updating the script will
be needed

Fixes: #42