### PR TITLE
Fixes #4: Automate launcher catalog update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A script that operates on all boosters under the `snowdrop` organization that ha
 
 Run `for-all-boosters.sh -h` for an overview of what the script can do and how to use it.
 
+Note that some commands can have the opportunity to run a command *after* all the boosters are processed. This is accomplished 
+using the `postCmd` variable when command line arguments are parsed. An example of this is the `catalog` command which calls 
+`postCmd="open_catalog_pr"` when the command is initialized. This results in the `open_catalog_pr` function being called *once*
+when all the boosters are processed. 
+
 ### Dependencies
 
 * bash 4.3 (to be able to use associative arrays). On macOS, `brew install bash` and make sure that `/usr/local/bin` is before `/bin` in your path.
@@ -58,9 +63,14 @@ Run `for-all-boosters.sh -h` for an overview of what the script can do and how t
 
   `./for-all-boosters.sh -m redhat -b crud fn fmp_deploy`
   
- * Add the maven wrapper to all boosters
+* Add the maven wrapper to all boosters
 
   `./for-all-boosters.sh -np cmd -p "SB-204: Add Maven Wrapper"  "mvn -N io.takari:maven:wrapper -Dmaven=3.3.9 && git add .mvn mvnw mvnw.cmd"`
+  
+* Update the `launcher-booster-catalog` automatically based on the most recently tagged version of the boosters. Note that this 
+  should only be called when the Spring Boot version has been updated, not for simple booster version updates.
+  
+  `./for-all-boosters.sh catalog`
 
 
 ## `sync-descriptors.sh`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Run `for-all-boosters.sh -h` for an overview of what the script can do and how t
 
 ### Dependencies
 
+* bash 4.3 (to be able to use associative arrays). On macOS, `brew install bash` and make sure that `/usr/local/bin` is before `/bin` in your path.
 * git
 * perl
 * mvn
@@ -60,7 +61,6 @@ Run `for-all-boosters.sh -h` for an overview of what the script can do and how t
  * Add the maven wrapper to all boosters
 
   `./for-all-boosters.sh -np cmd -p "SB-204: Add Maven Wrapper"  "mvn -N io.takari:maven:wrapper -Dmaven=3.3.9 && git add .mvn mvnw mvnw.cmd"`
-
 
 
 ## `sync-descriptors.sh`

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -807,8 +807,9 @@ catalog() {
 
         version_compare ${newSBVersion} ${oldSBVersion}
         if (( $? == 1 )); then
-            local -r newVersions=$(yq '.runtimes[] | select(.id == "spring-boot") | .versions[] | .name="'"${newSBVersion}"'.RELEASE"' ${metadataYAML} | jq '.' --slurp)
-            yq -y '.runtimes[] | select(.id == "spring-boot") | .versions='"${newVersions}" ${metadataYAML} > ${metadataYAML}.new
+            local -r newSBVersions=$(yq '.runtimes[] | select(.id == "spring-boot") | .versions[] | .name="'"${newSBVersion}"'.RELEASE"' ${metadataYAML} | jq '.' --slurp -c)
+            local -r newRuntimes=$(yq '.runtimes | map(if .id == "spring-boot" then .versions = '"${newSBVersions}"' else . end)' ${metadataYAML})
+            yq -y '.runtimes='"${newRuntimes}" ${metadataYAML} > ${metadataYAML}.new
             rm ${metadataYAML}
             mv ${metadataYAML}.new ${metadataYAML}
         fi

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -1120,6 +1120,7 @@ shift $((OPTIND - 1))
 
 subcommand=$1
 cmd=""
+declare postCmd
 case "$subcommand" in
     release)
         if [[ "$COMMIT" == off ]]; then
@@ -1359,6 +1360,15 @@ do
 
     fi
 done
+
+if [ -n "${postCmd}" ]; then
+    simple_log "Executing post-boosters processing command '${YELLOW}${postCmd}${BLUE}'"
+    if ! ${postCmd}; then
+        simple_log "Couldn't run ${YELLOW}${postCmd}"
+        echo
+    fi
+fi
+
 
 popd > /dev/null
 

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -1131,6 +1131,7 @@ case "$subcommand" in
     ;;
     catalog)
         cmd="catalog"
+        postCmd="open_catalog_pr"
     ;;
     create_branch)
         CREATE_BRANCH='on'
@@ -1175,7 +1176,7 @@ case "$subcommand" in
         if [ -n "$1" ]; then
             cmd="source $1"
         else
-            error "Must provide a script to execute"
+            error "Must provide a script to execute" 1>&2
         fi
     ;;
     revert)
@@ -1213,7 +1214,7 @@ case "$subcommand" in
         if [ -n "$2" ]; then
             cmd="set_maven_property $1 $2 ${run_verification}"
         else
-            error "Must provide a property name and a property value"
+            error "Must provide a property name and a property value" 1>&2
         fi
     ;;
     cmd)
@@ -1241,7 +1242,7 @@ case "$subcommand" in
         if [ -n "$1" ]; then
             cmd="run_cmd $1 ---- ${message}"
         else
-            error "Must provide a command to execute"
+            error "Must provide a command to execute" 1>&2
         fi
     ;;
     fn)
@@ -1251,7 +1252,7 @@ case "$subcommand" in
             shift # remove command name from args
             cmd="${cmd} $@" # append args
         else
-            error "Must provide a function to execute"
+            error "Must provide a function to execute" 1>&2
         fi
     ;;
     *)

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -436,6 +436,42 @@ replace_template_runtime_version_of_booster() {
     fi
 }
 
+parse_version() {
+    local -r currentVersion=${1}
+    local -r extract=${2:-components}
+
+    local -r versionRE='([1-9].[0-9].[0-9]+)-([0-9]+)-?([a-zA-Z0-9]+)?-?(SNAPSHOT)?'
+    if [[ "${currentVersion}" =~ ${versionRE} ]]; then
+        local -r sbVersion=${BASH_REMATCH[1]}
+        local -r versionInt=${BASH_REMATCH[2]}
+        local -r qualifier=${BASH_REMATCH[3]}
+        local -r snapshot=${BASH_REMATCH[4]}
+        case "$extract" in
+            sb)
+                declare -p sbVersion
+            ;;
+            own)
+                declare -p versionInt
+            ;;
+            qualifier)
+                declare -p qualifier
+            ;;
+            snapshot)
+                declare -p snapshot
+            ;;
+            components)
+                local -r components=( "${sbVersion}" "${versionInt}" "${qualifier}" "${snapshot}" )
+                declare -p components
+            ;;
+            *)
+                simple_log "Unknown extraction component: '${extract}'" 1>&2
+                return 1
+            ;;
+        esac
+    else
+        return 1
+    fi
+}
 
 # Based on https://stackoverflow.com/a/4025065
 # Returns 0 if both versions are equal, 1 if the first argument is greater, 2 if the second argument is greater

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -509,7 +509,7 @@ version_compare() {
     return 0
 }
 
-release() (
+release() {
     verify_maven_project_setup
 
     local -r currentVersion=$(evaluate_mvn_expr 'project.version')
@@ -631,10 +631,8 @@ release() (
     PUSH='on'
     push_to_remote "${remote}" "--tags"
 
-    # todo: update launcher catalog instead
-    log "Appending new version ${YELLOW}${releaseVersion}${BLUE} to ${YELLOW}${CATALOG_FILE}"
-    echo "${BOOSTER}: ${BRANCH} => ${releaseVersion}" >> "$CATALOG_FILE"
-)
+
+}
 
 do_revert() {
   local -r silence=${1:-false}

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -845,10 +845,10 @@ open_catalog_pr() {
     local -r catalogDir=$(prepare_catalog)
     pushd ${catalogDir} > /dev/null
     local -r sbVersion=$(cat "$(get_sb_version_file)")
-    git checkout -b "update-to-${sbVersion}" > /dev/null 2> /dev/null
+    local -r branchName="update-to-${sbVersion}"
+    git checkout -b "${branchName}" > /dev/null 2> /dev/null
     commit "Update Spring Boot to ${sbVersion}"
-    # todo: push the branch to snowdrop instead of fabric8-launcher
-    local -r pr=$(hub pull-request -p -b fabric8-launcher:master -m "DO NOT MERGE: Update Spring Boot to ${sbVersion}")
+    local -r pr=$(hub pull-request -p -h snowdrop:"${branchName}" -b fabric8-launcher:master -m "DO NOT MERGE: Update Spring Boot to ${sbVersion}")
     simple_log "Created PR: ${YELLOW}${pr}"
     popd > /dev/null
 }

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -827,8 +827,7 @@ catalog() {
 
         version_compare ${newSBVersion} ${oldSBVersion}
         if (( $? == 1 )); then
-            # todo: need to replace TODO by the appropriate version name below… :(
-            local -r newSBVersions=$(yq '.runtimes[] | select(.id == "spring-boot") | .versions[] | .name="'"${newSBVersion}"'.RELEASE ('"TODO"')"' ${metadataYAML} | jq '.' --slurp -c)
+            local -r newSBVersions=$(yq '.runtimes[] | select(.id == "spring-boot") | .versions | map(if .id == "current-community" then .name="'"${newSBVersion}"'.RELEASE (Community)" elif .id == "current-redhat" then .name="'"${newSBVersion}"'.RELEASE (RHOAR)" elif .id == "current-osio" then .name="'"${newSBVersion}"'.RELEASE (OSIO)" else . end)' ${metadataYAML})
             local -r newRuntimes=$(yq '.runtimes | map(if .id == "spring-boot" then .versions = '"${newSBVersions}"' else . end)' ${metadataYAML})
             yq -y '.runtimes='"${newRuntimes}" ${metadataYAML} > ${metadataYAML}.new
             rm ${metadataYAML}

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -436,6 +436,9 @@ replace_template_runtime_version_of_booster() {
     fi
 }
 
+# based on https://stackoverflow.com/a/10583562 for the components result.
+# Note that to retrieve the components, the variable must be named 'components' on the calling site and needs to be 'eval'ed:
+# local components; components=eval $(parse_version 1.5.13-2-SNAPSHOT)
 parse_version() {
     local -r currentVersion=${1}
     local -r extract=${2:-components}
@@ -448,16 +451,16 @@ parse_version() {
         local -r snapshot=${BASH_REMATCH[4]}
         case "$extract" in
             sb)
-                declare -p sbVersion
+                echo ${sbVersion}
             ;;
             own)
-                declare -p versionInt
+                echo ${versionInt}
             ;;
             qualifier)
-                declare -p qualifier
+                echo ${qualifier}
             ;;
             snapshot)
-                declare -p snapshot
+                echo ${snapshot}
             ;;
             components)
                 local -r components=( "${sbVersion}" "${versionInt}" "${qualifier}" "${snapshot}" )

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -759,7 +759,7 @@ prepare_catalog() {
     # clone launcher-catalog in temp dir if it doesn't already exist
     local -r catalogDir="${WORK_DIR}/launcher-booster-catalog"
     if [[ ! -d  ${catalogDir} ]]; then
-        log "Preparing launcher-booster-catalog temporary clone" 1>&2
+        log "Preparing launcher-booster-catalog temporary clone. Only done once." 1>&2
         if ! git clone git@github.com:snowdrop/launcher-booster-catalog.git ${catalogDir} 1>&2 2> /dev/null; then
             simple_log "Could not check out launcher-booster-catalog"
             return 1
@@ -815,7 +815,7 @@ catalog() {
     local -r newSBVersion=$(parse_version ${newVersion} sb)
     local -r sbVersionFile=$(get_sb_version_file)
     if [[ ! -f ${sbVersionFile} ]]; then
-        log "Recording new Spring Boot version ${YELLOW}${newSBVersion}${BLUE}"
+        log "Recording new Spring Boot version ${YELLOW}${newSBVersion}${BLUE}. Only done once."
         echo "${newSBVersion}" > "${sbVersionFile}"
     fi
 

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -805,7 +805,7 @@ catalog() {
         catalogMission=${simpleName}
     fi
 
-    local -r boosterYAML=${catalogDir}"/spring-boot/"${catalogVersion}"/"${catalogMission}"/booster.yaml"
+    local -r boosterYAML="${catalogDir}/spring-boot/${catalogVersion}/${catalogMission}/booster.yaml"
     if [[ ! -f ${boosterYAML} ]]; then
         log_failed "Couldn't find ${boosterYAML}"
         return 1

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -439,6 +439,8 @@ replace_template_runtime_version_of_booster() {
 # based on https://stackoverflow.com/a/10583562 for the components result.
 # Note that to retrieve the components, the variable must be named 'components' on the calling site and needs to be 'eval'ed:
 # local components; components=eval $(parse_version 1.5.13-2-SNAPSHOT)
+# For single component retrieval, regular evaluation can be used:
+# local -r sbVersion=$(parse_version 1.5.13-2-SNAPSHOT sb) will evaluate to '1.5.13'
 parse_version() {
     local -r currentVersion=${1}
     local -r extract=${2:-components}

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -1251,6 +1251,7 @@ case "$subcommand" in
             cmd="$1" # record command name
             shift # remove command name from args
             cmd="${cmd} $@" # append args
+            cmd=$(trim ${cmd})
         else
             error "Must provide a function to execute" 1>&2
         fi

--- a/for-all-boosters.sh
+++ b/for-all-boosters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A script to process boosters
 set -e


### PR DESCRIPTION
Updated `catalog` function to perform launcher update automatically. Could be called from `release` as well, though this isn't implemented yet.